### PR TITLE
Fix: Resolve generateMetadata error in forms page

### DIFF
--- a/app/(app)/[workspaceSlug]/forms/layout.tsx
+++ b/app/(app)/[workspaceSlug]/forms/layout.tsx
@@ -1,0 +1,16 @@
+export function generateMetadata({ params }: { params: { workspaceSlug: string } }) {
+  return {
+    title: `Forms - ${params.workspaceSlug}`,
+    description: 'Manage your forms and create new ones',
+  };
+}
+
+import { PropsWithChildren } from "react";
+
+export default function Layout({ children }: PropsWithChildren) {
+  return (
+    <div className="flex h-screen w-screen items-center justify-center">
+      {children}
+    </div>
+  );
+}

--- a/app/(app)/[workspaceSlug]/forms/page.tsx
+++ b/app/(app)/[workspaceSlug]/forms/page.tsx
@@ -90,12 +90,3 @@ export default function FormsPage({ params }: FormsPageProps) {
   );
 }
 
-// generateMetadata remains a server-side export if possible, or needs adjustment
-// For client components, metadata is typically handled differently (e.g. using Head from next/document or next/head)
-// However, Next.js 13+ app router allows generateMetadata in client component files too.
-export function generateMetadata({ params }: { params: { workspaceSlug: string } }) {
-  return {
-    title: `Forms - ${params.workspaceSlug}`,
-    description: 'Manage your forms and create new ones',
-  };
-}


### PR DESCRIPTION
The `generateMetadata` function was being exported from a client component (`app/(app)/[workspaceSlug]/forms/page.tsx`), which is disallowed in Next.js.

This commit resolves the issue by:
1. Creating a new `layout.tsx` file (`app/(app)/[workspaceSlug]/forms/layout.tsx`). This file is a Server Component by default.
2. Moving the `generateMetadata` function from `page.tsx` to the new `layout.tsx`.
3. Ensuring the `layout.tsx` exports a default layout component that renders its children.
4. Removing the `generateMetadata` function and its associated comments from `page.tsx`.

This ensures that `generateMetadata` is correctly handled within a Server Component context, aligning with Next.js best practices for the App Router.