### PR TITLE
feat: Implement Zustand store with bootstrap API for client state

### DIFF
--- a/app/(app)/[workspaceSlug]/forms/[formId]/page.tsx
+++ b/app/(app)/[workspaceSlug]/forms/[formId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { EnhancedFormEditor, FormHeader } from '@/components/forms/enhanced-form-components';
 import { db } from '@/lib/db';
 import { forms } from '@/lib/db/schema';

--- a/app/(app)/[workspaceSlug]/layout.tsx
+++ b/app/(app)/[workspaceSlug]/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { auth } from '@clerk/nextjs';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { getSubdomainContext } from '@/lib/subdomain';
 import { AppHeader } from '@/components/app/dashboard/app-header';
 import { AppSidebar } from '@/components/app/dashboard/app-sidebar';

--- a/app/(app)/[workspaceSlug]/members/page.tsx
+++ b/app/(app)/[workspaceSlug]/members/page.tsx
@@ -1,4 +1,4 @@
-import { getCurrentWorkspace, validateWorkspaceAccess } from '@/lib/workspace';
+import { getCurrentWorkspace, validateWorkspaceAccess } from '@/lib/workspace-server';
 import { MembersList, InviteMemberButton, MembersHeader } from '@/components/app/members/members-components';
 
 interface MembersPageProps {

--- a/app/(app)/[workspaceSlug]/page.tsx
+++ b/app/(app)/[workspaceSlug]/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { WelcomeBanner } from '@/components/app/dashboard/welcome-banner';
 import { DashboardStats, RecentForms, QuickActions } from '@/components/app/dashboard/dashboard-components';
 

--- a/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -1,4 +1,4 @@
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { WorkspaceSettings, SettingsNavigation } from '@/components/app/settings/settings-components';
 
 interface SettingsPageProps {

--- a/app/(app)/invite/page.tsx
+++ b/app/(app)/invite/page.tsx
@@ -18,7 +18,7 @@ import {
   Loader2,
   AlertCircle
 } from 'lucide-react';
-import { getWorkspaceUrl } from '@/lib/workspace';
+import { getWorkspaceUrl } from '@/lib/urls/workspace-urls';
 
 interface InvitationData {
   id: string;

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { auth } from '@clerk/nextjs';
 import { getSubdomainContext } from '@/lib/subdomain';
+import AppStoreInitializer from '@/components/shared/AppStoreInitializer';
 
 interface AppLayoutProps {
   children: ReactNode;
@@ -18,5 +19,5 @@ export default async function AppLayout({ children }: AppLayoutProps) {
   // Authentication checking will be done at the page level
   // since we need to allow access to login/signup pages
 
-  return <>{children}</>;
+  return <AppStoreInitializer>{children}</AppStoreInitializer>;
 }

--- a/app/(app)/onboarding/page.tsx
+++ b/app/(app)/onboarding/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@clerk/nextjs';
-import { getCurrentUserWorkspaces } from '@/lib/workspace';
+import { getCurrentUserWorkspaces } from '@/lib/workspace-server';
 import { AnimatedWorkspaceCreation } from '@/components/app/onboarding/animated-workspace-creation';
 
 export default async function OnboardingPage() {

--- a/app/api/bootstrap/route.ts
+++ b/app/api/bootstrap/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth, currentUser } from '@clerk/nextjs';
+
+import type {
+  BootstrapData,
+  BootstrapUserData,
+  BootstrapCurrentWorkspaceData,
+  BootstrapWorkspaceLimitsData,
+  BootstrapSeatLimitsData,
+  BootstrapFeaturesData,
+  BootstrapAbilitiesData,
+} from '@/lib/types/bootstrap';
+import type { WorkspaceWithRole } from '@/lib/types/workspace'; // WorkspaceWithRole is BootstrapCurrentWorkspaceData
+import type { Plan } from '@/lib/plans';
+
+import {
+  getUserSubscription,
+  getUserPlanLimits,
+  canCreateWorkspace,
+  getWorkspaceMemberUsage,
+  getWorkspaceUsage, // Added for currentWorkspacesOwned
+  PLAN_CONFIGS,
+} from '@/lib/plans';
+import {
+  getWorkspaceBySlug,
+  getUserDefaultWorkspace,
+  // getCurrentUserWorkspaces, // Not directly needed if getWorkspaceUsage provides count
+} from '@/lib/workspace-server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const clerkUser = await currentUser();
+    const url = new URL(request.url);
+    const workspaceSlug = url.searchParams.get('workspaceSlug');
+
+    // 1. User Data
+    const subscription = await getUserSubscription(userId);
+    const userPlan: Plan = subscription?.plan || 'starter';
+
+    const userData: BootstrapUserData = {
+      id: userId,
+      email: clerkUser?.emailAddresses[0]?.emailAddress || null,
+      firstName: clerkUser?.firstName || null,
+      lastName: clerkUser?.lastName || null,
+      profileImageUrl: clerkUser?.imageUrl || null,
+      plan: userPlan,
+      subscriptionStatus: subscription?.status || (userPlan === 'starter' ? 'active' : null), // Starter is active by default
+    };
+
+    // 2. Current Workspace Data
+    let currentWorkspace: BootstrapCurrentWorkspaceData = null; // Type is WorkspaceWithRole | null
+    if (workspaceSlug) {
+      currentWorkspace = await getWorkspaceBySlug(workspaceSlug);
+    } else {
+      currentWorkspace = await getUserDefaultWorkspace();
+    }
+
+    // 3. Workspace Limits Data
+    const planLimits = await getUserPlanLimits(userId); // PlanLimits type from lib/plans
+    const canCreate = await canCreateWorkspace(userId);
+    const usage = await getWorkspaceUsage(userId); // For currentWorkspacesOwned
+
+    const workspaceLimitsData: BootstrapWorkspaceLimitsData = {
+      maxWorkspaces: planLimits.maxWorkspaces,
+      currentWorkspacesOwned: usage ? usage.workspaces.used : 0,
+      canCreateMoreWorkspaces: canCreate.allowed,
+    };
+
+    // 4. Seat Limits Data
+    let seatLimitsData: BootstrapSeatLimitsData | null = null;
+    if (currentWorkspace) {
+      const memberUsage = await getWorkspaceMemberUsage(currentWorkspace.id, userId);
+      if (memberUsage) {
+        seatLimitsData = {
+          maxSeats: memberUsage.members.limit,
+          currentSeats: memberUsage.members.used,
+          canInviteMoreMembers: memberUsage.members.limit === -1 || memberUsage.members.used < memberUsage.members.limit,
+        };
+      }
+    }
+
+    // 5. Features Data
+    const featuresData: BootstrapFeaturesData = {
+      canInviteUsersToAnyWorkspace: PLAN_CONFIGS[userPlan].canInviteUsers,
+    };
+
+    // 6. Abilities Data
+    let abilitiesData: BootstrapAbilitiesData | null = null;
+    if (currentWorkspace && currentWorkspace.role) {
+      const role = currentWorkspace.role;
+      abilitiesData = {
+        canManageWorkspaceSettings: role === 'owner' || role === 'admin',
+        canManageMembers: role === 'owner' || role === 'admin',
+        canDeleteWorkspace: role === 'owner',
+      };
+    }
+
+    // 7. Compile BootstrapData
+    const bootstrapResponseData: BootstrapData = {
+      user: userData,
+      currentWorkspace,
+      workspaceLimits: workspaceLimitsData,
+      seatLimits: seatLimitsData,
+      features: featuresData,
+      abilities: abilitiesData,
+    };
+
+    return NextResponse.json(bootstrapResponseData);
+
+  } catch (error) {
+    console.error('Error fetching bootstrap data:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/invitations/route.ts
+++ b/app/api/invitations/route.ts
@@ -6,7 +6,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { eq, and } from 'drizzle-orm';
 import { ActivityLogger } from '@/lib/rbac';
 import { sendWelcomeEmail } from '@/lib/email';
-import { getWorkspaceUrl } from '@/lib/workspace';
+import { getWorkspaceUrl } from '@/lib/workspace-server';
 
 // GET - Validate invitation token and get invitation details
 export async function GET(req: NextRequest) {

--- a/app/api/workspace/onboard/route.ts
+++ b/app/api/workspace/onboard/route.ts
@@ -5,7 +5,7 @@ import { users, workspaceMembers, workspaceActivities } from '@/drizzle/schema';
 import { createId } from '@paralleldrive/cuid2';
 import { eq } from 'drizzle-orm';
 import { createDefaultSubscription } from '@/lib/plans';
-import { createWorkspaceFromEmail, getUserDefaultWorkspace } from '@/lib/workspace';
+import { createWorkspaceFromEmail, getUserDefaultWorkspace } from '@/lib/workspace-server';
 
 export async function POST(req: NextRequest) {
   try {

--- a/app/api/workspaces/[workspaceSlug]/current/route.ts
+++ b/app/api/workspaces/[workspaceSlug]/current/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { workspaceSlug: string } }
+) {
+  try {
+    const { workspaceSlug } = params;
+    const workspace = await getCurrentWorkspace(workspaceSlug);
+
+    if (workspace) {
+      return NextResponse.json(workspace, { status: 200 });
+    } else {
+      return NextResponse.json(
+        { error: 'Workspace not found' },
+        { status: 404 }
+      );
+    }
+  } catch (error) {
+    console.error('Error fetching current workspace:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/workspaces/by-id/[workspaceId]/invite/route.ts
+++ b/app/api/workspaces/by-id/[workspaceId]/invite/route.ts
@@ -6,7 +6,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { eq, and } from 'drizzle-orm';
 import { canInviteToWorkspace } from '@/lib/plans';
 import { checkWorkspacePermission, ActivityLogger } from '@/lib/rbac';
-import { validateWorkspaceAccess } from '@/lib/workspace';
+import { validateWorkspaceAccess } from '@/lib/workspace-server';
 import { sendInvitationEmail } from '@/lib/email';
 import { withErrorHandling, createSuccessResponse, ApiError, ErrorCodes, requireAuth, validateRequiredFields, requirePermission } from '@/lib/api-errors';
 import crypto from 'crypto';

--- a/app/api/workspaces/create/route.ts
+++ b/app/api/workspaces/create/route.ts
@@ -7,7 +7,7 @@ import {
   canCreateDefaultWorkspace,
   getWorkspaceLimitsInfo,
   isSlugAvailable 
-} from '@/lib/workspace';
+} from '@/lib/workspace-server';
 
 // Validation schema for workspace creation
 const createWorkspaceSchema = z.object({

--- a/app/app/[workspaceSlug]/forms/[formId]/page.tsx
+++ b/app/app/[workspaceSlug]/forms/[formId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { EnhancedFormEditor, FormHeader } from '@/components/forms/enhanced-form-components';
 import { db } from '@/lib/db';
 import { forms } from '@/lib/db/schema';

--- a/app/app/[workspaceSlug]/forms/page.tsx
+++ b/app/app/[workspaceSlug]/forms/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { FormsList, CreateFormButton, FormsHeader } from '@/components/forms/form-components';
 
 interface FormsPageProps {

--- a/app/app/[workspaceSlug]/layout.tsx
+++ b/app/app/[workspaceSlug]/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { auth } from '@clerk/nextjs';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { AppHeader } from '@/components/app/dashboard/app-header';
 import { AppSidebar } from '@/components/app/dashboard/app-sidebar';
 

--- a/app/app/[workspaceSlug]/members/page.tsx
+++ b/app/app/[workspaceSlug]/members/page.tsx
@@ -1,4 +1,4 @@
-import { getCurrentWorkspace, validateWorkspaceAccess } from '@/lib/workspace';
+import { getCurrentWorkspace, validateWorkspaceAccess } from '@/lib/workspace-server';
 import { MembersList, InviteMemberButton, MembersHeader } from '@/components/app/members/members-components';
 
 interface MembersPageProps {

--- a/app/app/[workspaceSlug]/page.tsx
+++ b/app/app/[workspaceSlug]/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { WelcomeBanner } from '@/components/app/dashboard/welcome-banner';
 import { DashboardStats, RecentForms, QuickActions } from '@/components/app/dashboard/dashboard-components';
 

--- a/app/app/[workspaceSlug]/settings/page.tsx
+++ b/app/app/[workspaceSlug]/settings/page.tsx
@@ -1,4 +1,4 @@
-import { getCurrentWorkspace } from '@/lib/workspace';
+import { getCurrentWorkspace } from '@/lib/workspace-server';
 import { WorkspaceSettings, SettingsNavigation } from '@/components/app/settings/settings-components';
 
 interface SettingsPageProps {

--- a/app/app/invite/page.tsx
+++ b/app/app/invite/page.tsx
@@ -18,7 +18,7 @@ import {
   Loader2,
   AlertCircle
 } from 'lucide-react';
-import { getWorkspaceUrl } from '@/lib/workspace';
+import { getWorkspaceUrl } from '@/lib/urls/workspace-urls';
 
 interface InvitationData {
   id: string;

--- a/app/app/onboarding/page.tsx
+++ b/app/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@clerk/nextjs';
-import { getCurrentUserWorkspaces } from '@/lib/workspace';
+import { getCurrentUserWorkspaces } from '@/lib/workspace-server';
 import { AnimatedWorkspaceCreation } from '@/components/app/onboarding/animated-workspace-creation';
 
 export default async function OnboardingPage() {

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs';
 import { redirect } from 'next/navigation';
-import { getUserDefaultWorkspace } from '@/lib/workspace';
+import { getUserDefaultWorkspace } from '@/lib/workspace-server';
 
 /**
  * App Root Page - /app

--- a/app/debug-workspace/[workspaceSlug]/page.tsx
+++ b/app/debug-workspace/[workspaceSlug]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from '@clerk/nextjs';
-import { getWorkspaceBySlug, getCurrentUserWorkspaces } from '@/lib/workspace';
+import { getWorkspaceBySlug, getCurrentUserWorkspaces } from '@/lib/workspace-server';
 
 /**
  * Debug page to check workspace access

--- a/components/app/dashboard/app-header.tsx
+++ b/components/app/dashboard/app-header.tsx
@@ -5,20 +5,33 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Bell, Search, Command } from 'lucide-react';
+import { useAppStore } from '@/lib/store/appStore';
 
-// Import client-safe types
-import type { WorkspaceWithRole } from '@/lib/types/workspace';
-interface AppHeaderProps {
-  workspace: WorkspaceWithRole;
-}
+// Removed WorkspaceWithRole import as it's not directly used by props anymore
+// import type { WorkspaceWithRole } from '@/lib/types/workspace';
 
-export function AppHeader({ workspace }: AppHeaderProps) {
-  // Ensure workspace is valid
-  if (!workspace) {
+// No more props needed for AppHeader after refactor
+// interface AppHeaderProps {
+// }
+
+export function AppHeader() {
+  const { currentWorkspace, isInitialized } = useAppStore();
+
+  // Handle loading state or if no workspace is active
+  // This also covers the case where the store is not yet initialized
+  if (!isInitialized || !currentWorkspace) {
     return (
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-16 items-center justify-center px-4 sm:px-6">
-          <div className="text-sm text-muted-foreground">Loading...</div>
+        <div className="container flex h-16 items-center justify-between px-4 sm:px-6">
+          {/* Show basic logo and UserButton even in loading/no workspace state */}
+          <h1 className="text-xl font-semibold text-foreground">ConvoForms</h1>
+          <UserButton
+            appearance={{
+              elements: {
+                avatarBox: "h-8 w-8"
+              }
+            }}
+          />
         </div>
       </header>
     );
@@ -28,8 +41,9 @@ export function AppHeader({ workspace }: AppHeaderProps) {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center px-4 sm:px-6">
         {/* Left: Logo/Brand */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
           <h1 className="text-xl font-semibold text-foreground">ConvoForms</h1>
+          {currentWorkspace && <Badge variant="outline">{currentWorkspace.name}</Badge>}
         </div>
 
         {/* Center: Enhanced Search */}

--- a/components/app/dashboard/welcome-banner.tsx
+++ b/components/app/dashboard/welcome-banner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { WorkspaceWithRole } from '@/lib/workspace';
+import type { WorkspaceWithRole } from '@/lib/types/workspace';
 import { Button } from '@/components/shared/ui/button';
 import { X, Sparkles } from 'lucide-react';
 

--- a/components/app/settings/settings-components.tsx
+++ b/components/app/settings/settings-components.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Settings, Users, CreditCard, Plug, AlertCircle } from 'lucide-react'
-import { getWorkspaceSettingsUrl } from '@/lib/workspace'
+import { getWorkspaceSettingsUrl } from '@/lib/urls/workspace-urls'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 

--- a/components/shared/AppStoreInitializer.tsx
+++ b/components/shared/AppStoreInitializer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, ReactNode } from 'react';
+import { useAppStore } from '@/lib/store/appStore';
+import { useAuth } from '@clerk/nextjs';
+
+interface AppStoreInitializerProps {
+  children: ReactNode;
+}
+
+export default function AppStoreInitializer({ children }: AppStoreInitializerProps) {
+  const { loadBootstrapData, isInitialized, isLoading, clearStore } = useAppStore();
+  const { isSignedIn, isLoaded: isClerkLoaded } = useAuth(); // Renamed to avoid conflict with store's isLoading
+
+  useEffect(() => {
+    if (isClerkLoaded) {
+      if (isSignedIn) {
+        // Only load if not already initialized and not currently loading
+        if (!isInitialized && !isLoading) {
+          console.log('AppStoreInitializer: User signed in, loading bootstrap data.');
+          loadBootstrapData();
+        }
+      } else {
+        // User is not signed in
+        if (isInitialized) { // Clear store only if it was previously initialized
+          console.log('AppStoreInitializer: User signed out, clearing store.');
+          clearStore();
+        }
+      }
+    }
+  }, [isSignedIn, isClerkLoaded, isInitialized, isLoading, loadBootstrapData, clearStore]);
+
+  // Show global loading indicator if:
+  // 1. Clerk auth state is not yet known OR
+  // 2. User is signed in, store is loading initial data, and store is not yet initialized.
+  if (!isClerkLoaded || (isSignedIn && isLoading && !isInitialized)) {
+    return (
+      <div style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+        fontSize: '1.2rem',
+        backgroundColor: '#f8f9fa' // A light background color
+      }}>
+        {/* You can replace this with a more sophisticated spinner/loader component */}
+        Loading application data...
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/lib/store/appStore.ts
+++ b/lib/store/appStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import type {
+  AppStoreState,
+  AppStoreActions,
+  BootstrapData,
+  // BootstrapCurrentWorkspaceData is WorkspaceWithRole | null, so directly use WorkspaceWithRole
+} from '@/lib/types/bootstrap';
+import type { WorkspaceWithRole } from '@/lib/types/workspace';
+
+// Define the store type
+type StoreType = AppStoreState & AppStoreActions;
+
+// Define the initial state
+const initialState: AppStoreState = {
+  user: null,
+  currentWorkspace: null,
+  workspaceLimits: null,
+  seatLimits: null,
+  features: null,
+  abilities: null,
+  isInitialized: false,
+  isLoading: false,
+};
+
+// Create the Zustand store
+export const useAppStore = create<StoreType>((set, get) => ({
+  ...initialState,
+
+  loadBootstrapData: async (workspaceSlug?: string) => {
+    set({ isLoading: true });
+    try {
+      let apiUrl = '/api/bootstrap';
+      if (workspaceSlug) {
+        apiUrl += `?workspaceSlug=${encodeURIComponent(workspaceSlug)}`;
+      }
+
+      const response = await fetch(apiUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch bootstrap data: ${response.statusText}`);
+      }
+
+      const data: BootstrapData = await response.json();
+
+      set({
+        user: data.user,
+        currentWorkspace: data.currentWorkspace,
+        workspaceLimits: data.workspaceLimits,
+        seatLimits: data.seatLimits,
+        features: data.features,
+        abilities: data.abilities,
+        isInitialized: true,
+        isLoading: false,
+      });
+    } catch (error)
+      console.error('Error loading bootstrap data:', error);
+      // Keep previous state or clear parts of it? For now, just stop loading.
+      // Consider setting isInitialized to true even on error to prevent infinite loading states.
+      set({ isLoading: false, isInitialized: true }); // Mark as initialized even on error
+    }
+  },
+
+  setCurrentWorkspaceDirectly: (workspace: WorkspaceWithRole | null) => {
+    set({ currentWorkspace: workspace });
+    // TODO: Consider if abilities and seatLimits should be re-evaluated or cleared here.
+    // For now, a full loadBootstrapData(workspace?.slug) might be safer if abilities/seatLimits
+    // for the new workspace are needed immediately and accurately without a full bootstrap.
+    // Or, set abilities/seatLimits to null and let a component trigger a refresh if needed.
+    set({ abilities: null, seatLimits: null });
+  },
+
+  clearStore: () => {
+    set({ ...initialState, isInitialized: false }); // Reset to initial state, including isInitialized
+  },
+}));

--- a/lib/types/bootstrap.ts
+++ b/lib/types/bootstrap.ts
@@ -1,0 +1,74 @@
+import type { WorkspaceWithRole, WorkspaceRole } from '@/lib/types/workspace';
+import type { Plan } from '@/lib/plans';
+
+// 1. User Data
+export interface BootstrapUserData {
+  id: string | null;
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profileImageUrl: string | null;
+  plan: Plan | null;
+  subscriptionStatus: string | null; // e.g., 'active', 'canceled', 'past_due'
+}
+
+// 2. Current Workspace Data
+export type BootstrapCurrentWorkspaceData = WorkspaceWithRole | null;
+
+// 3. Workspace Limits Data (for the user)
+export interface BootstrapWorkspaceLimitsData {
+  maxWorkspaces: number; // -1 for unlimited
+  currentWorkspacesOwned: number;
+  canCreateMoreWorkspaces: boolean;
+}
+
+// 4. Seat Limits Data (for the current workspace)
+export interface BootstrapSeatLimitsData {
+  maxSeats: number; // -1 for unlimited
+  currentSeats: number;
+  canInviteMoreMembers: boolean;
+}
+
+// 5. Features Data (global feature flags)
+export interface BootstrapFeaturesData {
+  canInviteUsersToAnyWorkspace: boolean; // Based on overall plan
+  // Add other global feature flags as needed
+}
+
+// 6. Abilities Data (contextual to current workspace & user's role)
+export interface BootstrapAbilitiesData {
+  canManageWorkspaceSettings: boolean;
+  canManageMembers: boolean;
+  canDeleteWorkspace: boolean;
+  // Add other specific abilities based on role
+}
+
+// 7. BootstrapData (API Response Structure)
+export interface BootstrapData {
+  user: BootstrapUserData | null;
+  currentWorkspace: BootstrapCurrentWorkspaceData; // This is WorkspaceWithRole | null
+  workspaceLimits: BootstrapWorkspaceLimitsData | null;
+  seatLimits: BootstrapSeatLimitsData | null; // Null if no workspace is active
+  features: BootstrapFeaturesData | null;
+  abilities: BootstrapAbilitiesData | null; // Null if no workspace is active or no specific abilities defined
+}
+
+// 8. AppStoreState (Zustand Store Shape)
+export interface AppStoreState {
+  user: BootstrapUserData | null;
+  currentWorkspace: BootstrapCurrentWorkspaceData;
+  workspaceLimits: BootstrapWorkspaceLimitsData | null;
+  seatLimits: BootstrapSeatLimitsData | null;
+  features: BootstrapFeaturesData | null;
+  abilities: BootstrapAbilitiesData | null;
+  isInitialized: boolean;
+  isLoading: boolean; // To track loading state of bootstrap call
+}
+
+// 9. AppStoreActions (Zustand Store Actions)
+export interface AppStoreActions {
+  loadBootstrapData: (workspaceSlug?: string) => Promise<void>;
+  setCurrentWorkspaceDirectly: (workspace: WorkspaceWithRole | null) => void;
+  clearStore: () => void;
+  // Potentially other actions like manually updating parts of the store
+}

--- a/lib/workspace-server.ts
+++ b/lib/workspace-server.ts
@@ -1,5 +1,5 @@
-// Server-side workspace operations (database dependencies)
-// DO NOT import this file in client components
+// IMPORTANT: This file contains server-side code only.
+// Do not import this file into client components.
 
 import { db } from '@/drizzle/db';
 import { workspaces, workspaceMembers, users } from '@/drizzle/schema';
@@ -10,9 +10,6 @@ import { cache } from 'react';
 import { createId } from '@paralleldrive/cuid2';
 import type { WorkspaceWithRole, WorkspaceRole } from '@/lib/types/workspace';
 import { getWorkspaceUrl } from '@/lib/context';
-
-// Re-export types for server components
-export type { WorkspaceWithRole, WorkspaceRole } from '@/lib/types/workspace';
 
 // Get all workspaces accessible by current user
 export const getCurrentUserWorkspaces = cache(async (): Promise<WorkspaceWithRole[]> => {


### PR DESCRIPTION
This commit introduces a global client-side state management solution using Zustand, populated by a new bootstrap API endpoint. This centralizes user, workspace, limits, features, and abilities data for easier access across client components.

Key changes:

1.  **Types Definition (`lib/types/bootstrap.ts`):**
    *   Defined `BootstrapData` for the API response structure.
    *   Defined `AppStoreState` and `AppStoreActions` for the Zustand store.

2.  **Bootstrap API Endpoint (`app/api/bootstrap/route.ts`):**
    *   Created a new GET endpoint that aggregates data for the authenticated user:
        *   User details from Clerk.
        *   Current workspace information (from slug or default).
        *   Subscription plan and status.
        *   Workspace and seat limits based on the plan.
        *   Feature flags derived from the plan.
        *   Contextual abilities based on your role in the current workspace.

3.  **Zustand Store Setup (`lib/store/appStore.ts`):**
    *   Implemented a Zustand store (`useAppStore`).
    *   Includes actions:
        *   `loadBootstrapData(workspaceSlug?)`: Fetches data from the bootstrap API and updates the store.
        *   `setCurrentWorkspaceDirectly(workspace)`: Allows direct update of the current workspace.
        *   `clearStore()`: Resets the store to initial state (e.g., on logout).

4.  **Store Initialization (`components/shared/AppStoreInitializer.tsx`):**
    *   Created a new client component that:
        *   Calls `loadBootstrapData` when an authenticated user loads the app.
        *   Clears the store on user logout.
        *   Displays a loading indicator during initial data fetch.
    *   Integrated this initializer into `app/(app)/layout.tsx` to make it global for the authenticated app experience.

5.  **Component Refactor (`components/app/dashboard/app-header.tsx`):**
    *   Refactored `AppHeader` to consume `currentWorkspace` and `isInitialized` from `useAppStore`, removing the need for prop drilling.
    *   The header now dynamically displays the current workspace name.