### PR TITLE
feat: Configure Playwright to run only on Chrome for E2E tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -61,41 +61,41 @@ export default defineConfig({
       dependencies: ['setup'],
     },
 
-    {
-      name: 'firefox',
-      use: { 
-        ...devices['Desktop Firefox'],
-        storageState: '.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //     storageState: '.auth/user.json',
+    //   },
+    //   dependencies: ['setup'],
+    // },
 
-    {
-      name: 'webkit',
-      use: { 
-        ...devices['Desktop Safari'],
-        storageState: '.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari'],
+    //     storageState: '.auth/user.json',
+    //   },
+    //   dependencies: ['setup'],
+    // },
 
-    /* Mobile testing */
-    {
-      name: 'Mobile Chrome',
-      use: { 
-        ...devices['Pixel 5'],
-        storageState: '.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
-    {
-      name: 'Mobile Safari',
-      use: { 
-        ...devices['iPhone 12'],
-        storageState: '.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
+    // /* Mobile testing */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //     storageState: '.auth/user.json',
+    //   },
+    //   dependencies: ['setup'],
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //     storageState: '.auth/user.json',
+    //   },
+    //   dependencies: ['setup'],
+    // },
 
     /* Test against branded browsers. */
     // {


### PR DESCRIPTION
Modified playwright.config.ts to streamline E2E testing by:
- Commenting out configurations for Firefox, WebKit, and mobile browsers.
- Ensuring tests run exclusively against the 'chromium' project.

This change helps in focusing E2E test runs on a single browser for faster sanity checks and debugging. Global setup/teardown and sample test files were reviewed, and no conflicts with this change were found. Mobile-specific tests are designed to be skipped automatically when not running on a mobile profile.