### PR TITLE
Fix: Resolve navigation and button placement UX issues

### DIFF
--- a/components/app/dashboard/app-header.tsx
+++ b/components/app/dashboard/app-header.tsx
@@ -4,8 +4,10 @@ import { UserButton } from '@clerk/nextjs';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Bell, Search, Command } from 'lucide-react';
+import { Bell, Search, Command, Plus } from 'lucide-react'; // Added Plus
 import { useAppStore } from '@/lib/store/appStore';
+import Link from 'next/link'; // Added Link
+import { getFormsUrl } from '@/lib/urls/workspace-urls'; // Added getFormsUrl
 
 // Removed WorkspaceWithRole import as it's not directly used by props anymore
 // import type { WorkspaceWithRole } from '@/lib/types/workspace';
@@ -63,8 +65,17 @@ export function AppHeader() {
             </div>
           </div>
           
-          {/* Right: Notifications + User */}
+          {/* Action Buttons Area */}
           <div className="flex items-center gap-2">
+            {/* NEW "Create Form" Button */}
+            <Button size="sm" asChild>
+              <Link href={getFormsUrl(currentWorkspace.slug, '/new')}>
+                <Plus className="h-4 w-4 mr-2" />
+                Create Form
+              </Link>
+            </Button>
+
+            {/* Existing Notifications Button */}
             <Button variant="ghost" size="sm" className="relative">
               <Bell className="h-4 w-4" />
               <Badge 
@@ -75,6 +86,7 @@ export function AppHeader() {
               </Badge>
             </Button>
             
+            {/* Existing UserButton */}
             <UserButton 
               appearance={{
                 elements: {

--- a/components/app/dashboard/app-sidebar.tsx
+++ b/components/app/dashboard/app-sidebar.tsx
@@ -168,32 +168,24 @@ export function AppSidebar({ workspace }: AppSidebarProps) {
     return hasPermission(workspace.role, item.requiresRole);
   };
 
+  const dashboardBasePath = getWorkspaceUrl(workspace.slug);
+
   const isActiveLink = (href: string) => {
-    // Remove query parameters for comparison
+    const cleanCurrentPath = pathname.split('?')[0];
     const cleanHref = href.split('?')[0];
-    
-    // For dashboard, exact match
-    if (cleanHref === `/${workspace.slug}`) {
-      return pathname === `/${workspace.slug}`;
+
+    if (cleanHref === dashboardBasePath) {
+      // Exact match for the dashboard path
+      return cleanCurrentPath === dashboardBasePath;
     }
     
-    // For other pages, check if pathname starts with href
-    return pathname.startsWith(cleanHref);
+    // For other pages, check if the current path starts with the link's href.
+    return cleanCurrentPath.startsWith(cleanHref);
   };
 
   return (
     <aside className="w-64 border-r bg-muted/10 h-[calc(100vh-64px)]">
       <div className="flex h-full flex-col gap-2 p-4">
-        {/* Quick Create Button */}
-        <Card className="p-4">
-          <Button className="w-full" size="sm" asChild>
-            <Link href={getFormsUrl(workspace.slug, '/new')}>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Form
-            </Link>
-          </Button>
-        </Card>
-
         {/* Navigation */}
         <nav className="flex flex-col space-y-1">
           {navItems.map((item) => {


### PR DESCRIPTION
This commit addresses several UX issues related to navigation and button placement:

1.  **Dashboard Link Highlighting:** Corrected the logic in the main sidebar to ensure the 'Dashboard' link is only highlighted when the user is on the exact dashboard page. Previously, it remained highlighted for all sub-pages of a workspace.

2.  **'Create Form' Button Relocation:** Moved the 'Create Form' button from the main sidebar to the top application header, positioning it as an action button on the right side. This improves visibility and follows common UX patterns for primary actions.

Note: The issue regarding secondary navigation visibility (always visible) was found to be outdated or a misunderstanding. The settings page's secondary navigation (`SettingsNavigation`) is already correctly scoped and only appears on the settings page, which is the desired behavior.