### PR TITLE
Fix: Address UX issues from #23 and improve auth redirects

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,9 +8,9 @@ CLERK_SECRET_KEY=
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/app/login
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/app/signup
 # These are paths after sign-in/up, relative to the app's context root.
-# '/dashboard' would typically resolve to something like /app/your-workspace-slug
-NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/dashboard
-NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/dashboard
+# '/app' will be handled by middleware to redirect to the appropriate workspace or onboarding.
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/app
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/app
 
 # Database - PostgreSQL
 # Local development (with Docker Compose)

--- a/app/app/[workspaceSlug]/forms/page.tsx
+++ b/app/app/[workspaceSlug]/forms/page.tsx
@@ -16,14 +16,19 @@ export default async function FormsPage({ params }: FormsPageProps) {
       {/* Forms Header with Search and Filters */}
       <FormsHeader workspace={workspace} />
 
-      {/* Create Form Button */}
-      <div className="flex justify-between items-center">
+      {/* Page Title and Create Form Button */}
+      <div className="flex justify-between items-center mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Forms</h1>
           <p className="mt-1 text-sm text-gray-500">
             Create and manage your conversational forms
           </p>
         </div>
+        {/* CreateFormButton is now part of FormsHeader or rendered separately if needed */}
+      </div>
+
+      {/* Create Form Button - Moved to be a direct child for consistent spacing */}
+      <div className="flex justify-end">
         <CreateFormButton workspace={workspace} />
       </div>
 


### PR DESCRIPTION
- Add bottom margin to the forms page title/header for better spacing.
- Investigated 'Create Form' button visibility in AppHeader; it depends on AppStore's currentWorkspace state.
- Update Clerk post-login and post-signup redirect URLs in `.env.local.example` to `/app`. This ensures consistency with middleware routing, directing users to their default workspace or onboarding flow.